### PR TITLE
Revert "Merge pull request #15 from rbkmoney/ft/fix-empty-id"

### DIFF
--- a/src/main/java/com/rbkmoney/cm/model/document/DocumentModificationModel.java
+++ b/src/main/java/com/rbkmoney/cm/model/document/DocumentModificationModel.java
@@ -10,7 +10,6 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @Entity
@@ -21,7 +20,6 @@ import javax.validation.constraints.NotNull;
 public class DocumentModificationModel extends ClaimModificationModel {
 
     @NotNull
-    @NotEmpty
     @Column(nullable = false)
     private String documentId;
 

--- a/src/test/java/com/rbkmoney/cm/handler/ClaimManagementHandlerTest.java
+++ b/src/test/java/com/rbkmoney/cm/handler/ClaimManagementHandlerTest.java
@@ -9,11 +9,9 @@ import com.rbkmoney.cm.service.ConversionWrapperService;
 import com.rbkmoney.cm.util.MockUtil;
 import com.rbkmoney.damsel.claim_management.*;
 import com.rbkmoney.damsel.msgpack.Value;
-import com.rbkmoney.woody.api.flow.error.WUndefinedResultException;
 import com.rbkmoney.woody.thrift.impl.http.THSpawnClientBuilder;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -35,7 +33,6 @@ import static org.mockito.ArgumentMatchers.any;
 
 public class ClaimManagementHandlerTest extends AbstractIntegrationTest {
 
-    public static final String EMPTY_STRING = "";
     @Autowired
     private ConversionWrapperService conversionWrapperService;
 
@@ -99,22 +96,6 @@ public class ClaimManagementHandlerTest extends AbstractIntegrationTest {
     public void testGetClaimWithWrongParty() {
         Claim claim = createClaim(client, conversionWrapperService, "party_id", 5);
         assertEquals(claim, callService(() -> client.getClaim("wrong_party", claim.getId())));
-    }
-
-    @Test(expected = WUndefinedResultException.class)
-    public void testTryingToEmptyDocumentID() {
-        Claim claim = createClaim(client, "claim_id", generateModifications(conversionWrapperService, () -> {
-            return MockUtil.generateTBaseList(Modification.claim_modification(createClaimModification()), 1);
-        }));
-    }
-
-    @NotNull
-    private ClaimModification createClaimModification() {
-        ClaimModification value = new ClaimModification();
-        DocumentModificationUnit documentModificationUnit = new DocumentModificationUnit();
-        documentModificationUnit.setId(EMPTY_STRING);
-        value.setDocumentModification(documentModificationUnit);
-        return value;
     }
 
     @Test

--- a/src/test/java/com/rbkmoney/cm/util/MockUtil.java
+++ b/src/test/java/com/rbkmoney/cm/util/MockUtil.java
@@ -70,7 +70,7 @@ public class MockUtil {
     }
 
     public static MockTBaseProcessor buildMockTBaseProcessor(Map.Entry<String[], FieldHandler>... fieldHandlers) {
-        MockTBaseProcessor mockTBaseProcessor = new MockTBaseProcessor(MockMode.RANDOM, 40, 5);
+        MockTBaseProcessor mockTBaseProcessor = new MockTBaseProcessor(MockMode.RANDOM, 10, 5);
         Arrays.stream(fieldHandlers).forEach(entry -> mockTBaseProcessor.addFieldHandler(entry.getValue(), entry.getKey()));
         return mockTBaseProcessor;
     }


### PR DESCRIPTION
This reverts commit b2e76df05eeffb876780888c6ceeabbe673e0663, reversing
changes made to 16a6ea6154aeb9a647de5daa3d9ceec3bb721e54.

Не увидел смысла в этой валидации, более того, стали флапать тесты. Такие валидации нужно выносить на swag, и к пустым строкам и нулам должны быть обработки на конечных сервисах. В данном случае, протокол позволяет пустые строки.