### PR TITLE
fix duplicate claim event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <db.password>postgres</db.password>
         <db.schema>cm</db.schema>
         <kafka.common.lib.version>0.1.7</kafka.common.lib.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.3</testcontainers.version>
         <shared.resources.version>0.3.8</shared.resources.version>
     </properties>
 
@@ -154,6 +154,11 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-quickstart</artifactId>
             <version>9.3.9.M1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/rbkmoney/cm/config/KafkaConsumerBeanEnableConfig.java
+++ b/src/main/java/com/rbkmoney/cm/config/KafkaConsumerBeanEnableConfig.java
@@ -1,7 +1,7 @@
 package com.rbkmoney.cm.config;
 
+import com.rbkmoney.cm.handler.event.ClaimEventSinkManager;
 import com.rbkmoney.cm.listener.ClaimEventSinkListener;
-import com.rbkmoney.cm.service.ClaimCommitterService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,8 +13,8 @@ public class KafkaConsumerBeanEnableConfig {
 
     @Bean
     @ConditionalOnProperty(value = "kafka.topics.claim-event-sink.enabled", havingValue = "true")
-    public ClaimEventSinkListener paymentEventsKafkaListener(ClaimCommitterService claimCommitterService) {
-        return new ClaimEventSinkListener(claimCommitterService);
+    public ClaimEventSinkListener paymentEventsKafkaListener(ClaimEventSinkManager claimEventSinkManager) {
+        return new ClaimEventSinkListener(claimEventSinkManager);
     }
 
 }

--- a/src/main/java/com/rbkmoney/cm/handler/event/ClaimEventHandler.java
+++ b/src/main/java/com/rbkmoney/cm/handler/event/ClaimEventHandler.java
@@ -1,0 +1,11 @@
+package com.rbkmoney.cm.handler.event;
+
+import com.rbkmoney.damsel.claim_management.Event;
+
+public interface ClaimEventHandler {
+
+    void handle(Event event);
+
+    boolean isHandle(Event event);
+
+}

--- a/src/main/java/com/rbkmoney/cm/handler/event/ClaimEventSinkManager.java
+++ b/src/main/java/com/rbkmoney/cm/handler/event/ClaimEventSinkManager.java
@@ -1,0 +1,34 @@
+package com.rbkmoney.cm.handler.event;
+
+import com.rbkmoney.damsel.claim_management.Event;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClaimEventSinkManager {
+
+    private final List<ClaimEventHandler> claimEventHandlerList;
+
+    @Transactional
+    public void handleEvent(Event event, Acknowledgment ack) {
+        try {
+            for (ClaimEventHandler claimEventHandler : claimEventHandlerList) {
+                if (claimEventHandler.isHandle(event)) {
+                    claimEventHandler.handle(event);
+                }
+            }
+            ack.acknowledge();
+        } catch (Exception ex) {
+            log.error("Failed to process event, event='{}'", event, ex);
+            throw ex;
+        }
+    }
+
+}

--- a/src/main/java/com/rbkmoney/cm/handler/event/ClaimStatusChangeEventHandler.java
+++ b/src/main/java/com/rbkmoney/cm/handler/event/ClaimStatusChangeEventHandler.java
@@ -1,0 +1,36 @@
+package com.rbkmoney.cm.handler.event;
+
+import com.rbkmoney.cm.service.ClaimCommitterService;
+import com.rbkmoney.damsel.claim_management.ClaimStatusChanged;
+import com.rbkmoney.damsel.claim_management.Event;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClaimStatusChangeEventHandler implements ClaimEventHandler {
+
+    private final ClaimCommitterService claimCommitterService;
+
+    @Transactional
+    public void handle(Event event) {
+        ClaimStatusChanged claimStatusChanged = event.getChange().getStatusChanged();
+        if (claimStatusChanged.getStatus().isSetPendingAcceptance()) {
+            log.info("Commit claim in 'pending_acceptance' status, event='{}'", event);
+            claimCommitterService.doCommitClaim(
+                    claimStatusChanged.getPartyId(),
+                    claimStatusChanged.getId(),
+                    claimStatusChanged.getRevision()
+            );
+        }
+    }
+
+    @Override
+    public boolean isHandle(Event event) {
+        return event.getChange().isSetStatusChanged();
+    }
+
+}

--- a/src/main/java/com/rbkmoney/cm/listener/ClaimEventSinkListener.java
+++ b/src/main/java/com/rbkmoney/cm/listener/ClaimEventSinkListener.java
@@ -1,7 +1,6 @@
 package com.rbkmoney.cm.listener;
 
-import com.rbkmoney.cm.service.ClaimCommitterService;
-import com.rbkmoney.damsel.claim_management.ClaimStatusChanged;
+import com.rbkmoney.cm.handler.event.ClaimEventSinkManager;
 import com.rbkmoney.damsel.claim_management.Event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,31 +13,18 @@ import org.springframework.messaging.handler.annotation.Header;
 @RequiredArgsConstructor
 public class ClaimEventSinkListener {
 
-    private final ClaimCommitterService claimCommitterService;
+    private final ClaimEventSinkManager claimEventSinkManager;
 
     @KafkaListener(topics = "${kafka.topics.claim-event-sink.id}", containerFactory = "kafkaListenerContainerFactory")
-    public void handle(Event event,
-                       @Header(KafkaHeaders.RECEIVED_PARTITION_ID) int partition,
-                       @Header(KafkaHeaders.OFFSET) int offsets,
-                       Acknowledgment ack) {
-        if (event.getChange().isSetStatusChanged()) {
-            ClaimStatusChanged claimStatusChanged = event.getChange().getStatusChanged();
-            if (claimStatusChanged.getStatus().isSetPendingAcceptance()) {
-                log.info("Found event in 'pending_acceptance' status, event='{}'", event);
-                try {
-                    claimCommitterService.doCommitClaim(
-                            claimStatusChanged.getPartyId(),
-                            claimStatusChanged.getId(),
-                            claimStatusChanged.getRevision()
-                    );
-                    ack.acknowledge();
-                    log.info("Event have been processed, event='{}'", event);
-                } catch (Exception ex) {
-                    log.error("Failed to process event, event='{}'", event, ex);
-                    throw ex;
-                }
-            }
-        }
+    public void handle(
+            Event event,
+            @Header(KafkaHeaders.RECEIVED_PARTITION_ID) int partition,
+            @Header(KafkaHeaders.OFFSET) int offsets,
+            Acknowledgment ack
+    ) {
+        log.info("Handle event={}; partition={}; offsets={}", event, partition, offsets);
+        claimEventSinkManager.handleEvent(event, ack);
+        log.info("Event have been processed, event={}; partition={}; offsets={}", event, partition, offsets);
     }
 
 }

--- a/src/test/java/com/rbkmoney/cm/ClaimEventListenerTest.java
+++ b/src/test/java/com/rbkmoney/cm/ClaimEventListenerTest.java
@@ -63,7 +63,7 @@ public class ClaimEventListenerTest extends AbstractKafkaIntegrationTest {
     @Test
     public void testClaimStatusChangeHandler() throws InterruptedException, ExecutionException {
         // Given
-        String partyId = UUID.randomUUID().toString();
+        final String partyId = UUID.randomUUID().toString();
         Event event = new Event();
         event.setOccuredAt(TypeUtil.temporalToString(LocalDateTime.now()));
         Change change = new Change();

--- a/src/test/java/com/rbkmoney/cm/ClaimEventListenerTest.java
+++ b/src/test/java/com/rbkmoney/cm/ClaimEventListenerTest.java
@@ -1,0 +1,93 @@
+package com.rbkmoney.cm;
+
+import com.rbkmoney.cm.meta.UserIdentityEmailExtensionKit;
+import com.rbkmoney.cm.meta.UserIdentityIdExtensionKit;
+import com.rbkmoney.cm.meta.UserIdentityRealmExtensionKit;
+import com.rbkmoney.cm.meta.UserIdentityUsernameExtensionKit;
+import com.rbkmoney.cm.model.*;
+import com.rbkmoney.cm.repository.ClaimRepository;
+import com.rbkmoney.cm.service.ClaimManagementService;
+import com.rbkmoney.cm.service.ConversionWrapperService;
+import com.rbkmoney.damsel.claim_management.*;
+import com.rbkmoney.geck.common.util.TypeUtil;
+import com.rbkmoney.woody.thrift.impl.http.THSpawnClientBuilder;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static com.rbkmoney.cm.util.ServiceUtils.createClaim;
+import static com.rbkmoney.cm.util.ServiceUtils.runService;
+
+public class ClaimEventListenerTest extends AbstractKafkaIntegrationTest {
+
+    @Autowired
+    private ClaimManagementService claimManagementService;
+
+    @Autowired
+    private ClaimRepository claimRepository;
+
+    @Autowired
+    private ConversionWrapperService conversionWrapperService;
+
+    private ClaimManagementSrv.Iface client;
+
+    @Before
+    public void setUp() throws Exception {
+        client = new THSpawnClientBuilder()
+                .withAddress(new URI("http://localhost:" + port + "/v1/cm"))
+                .withNetworkTimeout(-1)
+                .withMetaExtensions(
+                        List.of(
+                                UserIdentityIdExtensionKit.INSTANCE,
+                                UserIdentityUsernameExtensionKit.INSTANCE,
+                                UserIdentityEmailExtensionKit.INSTANCE,
+                                UserIdentityRealmExtensionKit.INSTANCE
+                        )
+                )
+                .build(ClaimManagementSrv.Iface.class);
+        claimRepository.deleteAll();
+    }
+
+    @Test
+    public void testClaimStatusChangeHandler() throws InterruptedException, ExecutionException {
+        // Given
+        String partyId = UUID.randomUUID().toString();
+        Event event = new Event();
+        event.setOccuredAt(TypeUtil.temporalToString(LocalDateTime.now()));
+        Change change = new Change();
+        ClaimStatusChanged claimStatusChanged = new ClaimStatusChanged();
+        claimStatusChanged.setId(1);
+        claimStatusChanged.setPartyId(partyId);
+        claimStatusChanged.setStatus(ClaimStatus.pending_acceptance(new ClaimPendingAcceptance()));
+        claimStatusChanged.setRevision(0);
+        claimStatusChanged.setUpdatedAt(TypeUtil.temporalToString(LocalDateTime.now()));
+        change.setStatusChanged(claimStatusChanged);
+        event.setChange(change);
+
+        // When
+        Claim pendingClaim = createClaim(client, conversionWrapperService, partyId, 5);
+        runService(() -> client.acceptClaim(partyId, pendingClaim.getId(), 0));
+        Producer<String, Event> producer = createProducer();
+        ProducerRecord<String, Event> producerRecord = new ProducerRecord<>(eventSinkTopic, partyId, event);
+        producer.send(producerRecord).get();
+
+        // Then
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).pollDelay(Durations.ONE_SECOND).until(() -> {
+            ClaimModel claim = claimManagementService.getClaim(partyId, 1);
+            return claim != null && claim.getClaimStatus().getClaimStatusEnum() == ClaimStatusEnum.accepted;
+        });
+    }
+
+}

--- a/src/test/java/com/rbkmoney/cm/ClaimEventListenerTest.java
+++ b/src/test/java/com/rbkmoney/cm/ClaimEventListenerTest.java
@@ -4,7 +4,8 @@ import com.rbkmoney.cm.meta.UserIdentityEmailExtensionKit;
 import com.rbkmoney.cm.meta.UserIdentityIdExtensionKit;
 import com.rbkmoney.cm.meta.UserIdentityRealmExtensionKit;
 import com.rbkmoney.cm.meta.UserIdentityUsernameExtensionKit;
-import com.rbkmoney.cm.model.*;
+import com.rbkmoney.cm.model.ClaimModel;
+import com.rbkmoney.cm.model.ClaimStatusEnum;
 import com.rbkmoney.cm.repository.ClaimRepository;
 import com.rbkmoney.cm.service.ClaimManagementService;
 import com.rbkmoney.cm.service.ConversionWrapperService;
@@ -21,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.net.URI;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -67,14 +67,14 @@ public class ClaimEventListenerTest extends AbstractKafkaIntegrationTest {
         Event event = new Event();
         event.setOccuredAt(TypeUtil.temporalToString(LocalDateTime.now()));
         Change change = new Change();
+        event.setChange(change);
         ClaimStatusChanged claimStatusChanged = new ClaimStatusChanged();
+        change.setStatusChanged(claimStatusChanged);
         claimStatusChanged.setId(1);
         claimStatusChanged.setPartyId(partyId);
         claimStatusChanged.setStatus(ClaimStatus.pending_acceptance(new ClaimPendingAcceptance()));
         claimStatusChanged.setRevision(0);
         claimStatusChanged.setUpdatedAt(TypeUtil.temporalToString(LocalDateTime.now()));
-        change.setStatusChanged(claimStatusChanged);
-        event.setChange(change);
 
         // When
         Claim pendingClaim = createClaim(client, conversionWrapperService, partyId, 5);


### PR DESCRIPTION
Исправлена проблема при которой транзакция в базу завершалась успешно, а kafka коммит фейлился.
Исходя из этой ошибки появились event'ы которые уже обработаны, но из-за повторной попытки их сохранить выбрасывает ошибку с revisionId, так как эти события уже устарели. Идея в том чтобы игнорировать события revisionId которых меньше текущего в базе. Кажется, что в таких событиях нет никакого смысла